### PR TITLE
Bug in Lock() method causing it to wait indefinitely

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -101,6 +101,9 @@ func (l *Lock) Lock() error {
 		_, _, ch, err := l.c.GetW(l.path + "/" + prevSeqPath)
 		if err != nil && err != ErrNoNode {
 			return err
+		} else if err != nil && err == ErrNoNode {
+			// try again
+			continue
 		}
 
 		ev := <-ch


### PR DESCRIPTION
I noticed a bug when using Lock() method which causes it to wait indefinitely listening on an uninitialised channel. Very quick fix which is compliant with the zookeeper recipe spec http://zookeeper.apache.org/doc/r3.4.5/recipes.html#sc_recipes_Locks
