### PR TITLE
add a path from ubuntu's zookeeper's package: apt-get install zookeeper

### DIFF
--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -88,6 +88,7 @@ var jarSearchPaths = []string{
 	"../zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
 	"/usr/local/zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
 	"/usr/local/Cellar/zookeeper/*/libexec/contrib/fatjar/zookeeper-*-fatjar.jar",
+	"/usr/share/java/zookeeper-*.jar",
 }
 
 func findZookeeperFatJar() string {


### PR DESCRIPTION
I was trying to test my usage of this library but did not have the zookeeper at the existing paths. The path i've added is what is installed with the ubuntu 13.10 zookeeper package.
