### PR TITLE
Added ability to wait for correct shutdown

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -142,6 +142,7 @@ func ConnectWithDialer(servers []string, recvTimeout time.Duration, dialer Diale
 		conn.loop()
 		conn.flushRequests(ErrClosing)
 		conn.invalidateWatches(ErrClosing)
+		close(conn.eventChan)
 	}()
 	return &conn, ec, nil
 }


### PR DESCRIPTION
Hi

I'd really like to know when the connection to the cluster is finally shut down. The easiest and most go-like way seems to me to close the event channel.

Regards
Hannes
