### PR TITLE
flush unsent request if err happens and set read timeout on prime conn...

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -255,6 +255,7 @@ func (c *Conn) loop() {
 		if err != ErrSessionExpired {
 			err = ErrConnectionClosed
 		}
+		c.flushUnsentRequests(err)
 		c.flushRequests(err)
 
 		if c.reconnectDelay > 0 {
@@ -375,6 +376,7 @@ func (c *Conn) authenticate() error {
 	// connect response
 
 	// package length
+	c.conn.SetReadDeadline(time.Now().Add(c.recvTimeout))
 	_, err = io.ReadFull(c.conn, buf[:4])
 	if err != nil {
 		return err
@@ -389,6 +391,7 @@ func (c *Conn) authenticate() error {
 	if err != nil {
 		return err
 	}
+	c.conn.SetReadDeadline(time.Now().Add(c.recvTimeout))
 
 	r := connectResponse{}
 	_, err = decodePacket(buf[:blen], &r)


### PR DESCRIPTION
In our case, the client can't initialize session on prime connection bcs the zookeeper server shuts down. It stays for some time leading to lots of "sendSetWatches" goroutines which occupy too much memory. We should also flush unsent requests to avoid oom whenever errors happen.
Occasionally the client blocks in reading connection response. We should add read timeout for reading response.
