### PR TITLE
Add timeouts around IO calls during authenticate

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -365,7 +365,9 @@ func (c *Conn) authenticate() error {
 
 	binary.BigEndian.PutUint32(buf[:4], uint32(n))
 
+	c.conn.SetWriteDeadline(time.Now().Add(c.recvTimeout * 10))
 	_, err = c.conn.Write(buf[:n+4])
+	c.conn.SetWriteDeadline(time.Time{})
 	if err != nil {
 		return err
 	}
@@ -375,7 +377,9 @@ func (c *Conn) authenticate() error {
 	// connect response
 
 	// package length
+	c.conn.SetReadDeadline(time.Now().Add(c.recvTimeout * 10))
 	_, err = io.ReadFull(c.conn, buf[:4])
+	c.conn.SetReadDeadline(time.Time{})
 	if err != nil {
 		return err
 	}

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -3,7 +3,6 @@ package zk
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strings"
 	"testing"
@@ -494,7 +493,7 @@ func startSlowProxy(t *testing.T, up, down throttle.Rate, upstream string, adj f
 				defer cn.Close()
 				upcn, err := net.Dial("tcp", upstream)
 				if err != nil {
-					log.Print(err)
+					t.Log(err)
 					return
 				}
 				// This will leave hanging goroutines util stopCh is closed


### PR DESCRIPTION
We actually ended up with a process that was completely blocked trying to `io.ReadFull` from a connection that may never have responded. It seemed like it might be best to have some form of timeout. I chose to do the `* 10` to keep the test suite green and allow for slightly longer authenticate calls as they are made only as part of a new connection.