### PR TITLE
Wrap connection Xid back to zero rather than overflowing to negative int32

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -15,7 +15,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -584,7 +586,22 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 }
 
 func (c *Conn) nextXid() int32 {
-	return atomic.AddInt32(&c.xid, 1)
+	var xid int32
+	for {
+		xid = atomic.LoadInt32(&c.xid)
+		if xid >= math.MaxInt32-2 {
+			if atomic.CompareAndSwapInt32(&c.xid, xid, 0) {
+				buf := make([]byte, 65536)
+				runtime.Stack(buf, false)
+				log.Printf("Connection xid overflow, wrapped to zero\n%s", buf)
+				return 0
+			}
+		} else {
+			if atomic.CompareAndSwapInt32(&c.xid, xid, xid+1) {
+				return xid + 1
+			}
+		}
+	}
 }
 
 func (c *Conn) addWatcher(path string, watchType watchType) <-chan Event {


### PR DESCRIPTION
It's better to wrap the counter to zero than to a negative value.

Aside from that, cranking the counter up that high probably indicates a problem elsewhere (a tight retry loop perhaps), and logging the stack trace at the time of wrap is likely (but not certain) to point to the culprit.