### PR TITLE
fixed race around global resource

### DIFF
--- a/zk/util.go
+++ b/zk/util.go
@@ -5,7 +5,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"sync"
 )
+
+var shuffleMutex sync.Mutex
 
 // AuthACL produces an ACL list containing a single ACL which uses the
 // provided permissions, with the scheme "auth", and ID "", which is used
@@ -33,8 +36,10 @@ func DigestACL(perms int32, user, password string) []ACL {
 
 // stringShuffle performs a Fisher-Yates shuffle on a slice of strings
 func stringShuffle(s []string) {
+	shuffleMutex.Lock()
+	defer shuffleMutex.Unlock()
 	for i := len(s) - 1; i > 0; i-- {
-		j := rand.Intn(i + 1)
+		j := rand.Intn(i + 1) //global object
 		s[i], s[j] = s[j], s[i]
 	}
 }


### PR DESCRIPTION
stringShuffle uses rand.Intn, which is global, and when multple threads call ConnectWithDialer a race between threads will occur on the rand library. 