### PR TITLE
add a Logger interface and setter for the logging Printf calls

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -14,9 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,7 +22,10 @@ import (
 	"time"
 )
 
-var ErrNoServer = errors.New("zk: could not connect to a server")
+var (
+	ErrNoServer   = errors.New("zk: could not connect to a server")
+	DefaultLogger = defaultLogger{}
+)
 
 const (
 	bufferSize      = 1536 * 1024
@@ -150,9 +151,6 @@ func ConnectWithDialer(servers []string, sessionTimeout time.Duration, dialer Di
 	if dialer == nil {
 		dialer = net.DialTimeout
 	}
-
-	newLogger := log.New(os.Stderr, "", log.LstdFlags)
-
 	conn := Conn{
 		dialer:          dialer,
 		servers:         srvs,
@@ -170,7 +168,7 @@ func ConnectWithDialer(servers []string, sessionTimeout time.Duration, dialer Di
 		watchers:        make(map[watchPathType][]chan Event),
 		passwd:          emptyPassword,
 		timeout:         int32(sessionTimeout.Nanoseconds() / 1e6),
-		logger:          newLogger,
+		logger:          DefaultLogger,
 
 		// Debug
 		reconnectDelay: 0,
@@ -284,7 +282,7 @@ func (c *Conn) loop() {
 
 		// Yeesh
 		if err != io.EOF && err != ErrSessionExpired && !strings.Contains(err.Error(), "use of closed network connection") {
-			c.logger.Printf("%s\n", err)
+			c.logger.Printf(err.Error())
 		}
 
 		select {

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -3,6 +3,7 @@ package zk
 import (
 	"encoding/binary"
 	"errors"
+	"log"
 	"reflect"
 	"runtime"
 	"time"
@@ -13,6 +14,12 @@ var (
 	ErrPtrExpected        = errors.New("zk: encode/decode expect a non-nil pointer to struct")
 	ErrShortBuffer        = errors.New("zk: buffer too small")
 )
+
+type defaultLogger struct{}
+
+func (defaultLogger) Printf(format string, a ...interface{}) {
+	log.Printf(format, a...)
+}
 
 type ACL struct {
 	Perms  int32


### PR DESCRIPTION
By adding this Logger interface, and by fulfilling the interface with a function that has no body, you can silence the log messages from the *zk.Conn instance. The `Connect()` and `ConnectWithDialer()` functions both set the logger up by default to log to `Stderr`.

Fixes #60.