### PR TITLE
remove unused StateSyncConnected

### DIFF
--- a/zk/constants.go
+++ b/zk/constants.go
@@ -57,7 +57,6 @@ const (
 	StateUnknown           = State(-1)
 	StateDisconnected      = State(0)
 	StateConnecting        = State(1)
-	StateSyncConnected     = State(3)
 	StateAuthFailed        = State(4)
 	StateConnectedReadOnly = State(5)
 	StateSaslAuthenticated = State(6)
@@ -77,7 +76,6 @@ var (
 	stateNames = map[State]string{
 		StateUnknown:           "StateUnknown",
 		StateDisconnected:      "StateDisconnected",
-		StateSyncConnected:     "StateSyncConnected",
 		StateConnectedReadOnly: "StateConnectedReadOnly",
 		StateSaslAuthenticated: "StateSaslAuthenticated",
 		StateExpired:           "StateExpired",


### PR DESCRIPTION
Looks like "StateSyncConnected" is not used anywhere.
Can we remove it for better code reading ?
