### PR TITLE
Re-derive timeouts from the negotiated session timeout

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -464,6 +464,7 @@ func (c *Conn) authenticate() error {
 	}
 
 	c.timeout = r.TimeOut
+	c.recvTimeout = time.Duration(r.TimeOut) * time.Millisecond * 2 / 3
 	c.sessionID = r.SessionID
 	c.passwd = r.Passwd
 	c.setState(StateHasSession)


### PR DESCRIPTION
After connecting to a server, a new negotiated session timeout is set. The two commits in this pull request update the client to re-derive the receive timeout and ping interval from the new session timeout. It also changes ping behavior to only send pings when there isn't already communication.

These seem like straightforward bug fixes. Let me know what you think.