### PR TITLE
Invalidate watchers when error in loop()

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -305,6 +305,7 @@ func (c *Conn) loop() {
 			err = ErrConnectionClosed
 		}
 		c.flushRequests(err)
+		c.invalidateWatches(err)
 
 		if c.reconnectDelay > 0 {
 			select {


### PR DESCRIPTION
In loop() function, when network error happens, sendLoop() and recvLoop() return for the next connection. loop() also flushes existing requests before reconnecting. Yet watchers should be also notified.

Without the patch watchers won't receive event. And if network error persists, the next connect() would never succeed and watchers will be waiting forever.