### PR TITLE
Never reset Conn.xid (fixes #5)

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -463,9 +463,6 @@ func (c *Conn) authenticate() error {
 		return ErrSessionExpired
 	}
 
-	if c.sessionID != r.SessionID {
-		atomic.StoreUint32(&c.xid, 0)
-	}
 	c.timeout = r.TimeOut
 	c.sessionID = r.SessionID
 	c.passwd = r.Passwd

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -32,7 +32,7 @@ var ErrNoServer = errors.New("zk: could not connect to a server")
 var ErrInvalidPath = errors.New("zk: invalid path")
 
 // DefaultLogger uses the stdlib log package for logging.
-var DefaultLogger = defaultLogger{}
+var DefaultLogger Logger = defaultLogger{}
 
 const (
 	bufferSize      = 1536 * 1024


### PR DESCRIPTION
A bug was discovered that several requests can be assigned the same `xid`. The reason for that is that the `Conn.autheticate()` function can reset `Conn.xid` to 0. A solution that this PR suggests is to never reset the `Conn.xid`, it only needs to be unique for every request after all.
 