### PR TITLE
Allow setting chroot for a connection

### DIFF
--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -1,0 +1,59 @@
+package zk
+
+import "testing"
+
+func TestChroot(t *testing.T) {
+	ts, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk, _, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	defer zk.Close()
+
+	zkChroot, _, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	defer zkChroot.Close()
+	zkChroot.SetChroot("/testchroot")
+
+	// create chroot
+	if _, err := zk.Create("/testchroot", []byte{}, 0, WorldACL(PermAll)); err != nil {
+		t.Fatalf("unable to create /testchroot, err=%q", err)
+	}
+	defer func() {
+		_, stat, _ := zk.Get("/testchroot")
+		err := zk.Delete("/testchroot", stat.Version)
+		if err != nil {
+			t.Errorf("failed deleting /testchroot, err=%q", err)
+		}
+	}()
+
+	// create node in chroot
+	_, err = zkChroot.Create("/node", []byte{}, 0, WorldACL(PermAll))
+	if err != nil {
+		t.Fatalf("create err=%q", err)
+	}
+	defer func() {
+		_, stat, _ := zkChroot.Get("/node")
+		err := zkChroot.Delete("/node", stat.Version)
+		if err != nil {
+			t.Errorf("failed deleting /testchroot/node, err=%q", err)
+		}
+	}()
+
+	// check if node is visible
+	exists, _, err := zk.Exists("/testchroot/node")
+	if err != nil {
+		t.Fatalf("exists err=%q", err)
+	}
+	if !exists {
+		t.Errorf("could not find /testchroot/node")
+	}
+
+}


### PR DESCRIPTION
Added simple chroot support, requested in #32. 

Conn gets a `SetChroot` function which fiddles with the path of any requests which use a path.

It has a known bug: if the Chroot'd connection is asked to work on paths that look like the chroot itself, it will do things to the wrong directory. In particular, if you do this:
```
conn.SetChroot("/a/b")
conn.Create("/a/b/c", []byte{}, 0, WorldACL(PermAll))
```
Then you will not get a node written to "/a/b/a/b/c", as you might expect - it will go to "/a/b/c". This is unfortunate, but hard to avoid.

Also, we don't currently fiddle with response Paths, which is probably flat-out wrong...