### PR TITLE
Fix nil pointer error in FLWSrvr

### DIFF
--- a/zk/flw.go
+++ b/zk/flw.go
@@ -49,14 +49,16 @@ func FLWSrvr(servers []string, timeout time.Duration) ([]*ServerStats, bool) {
 			continue
 		}
 
-		match := re.FindAllStringSubmatch(string(response), -1)[0][1:]
+		matches := re.FindAllStringSubmatch(string(response), -1)
 
-		if match == nil {
+		if matches == nil {
 			err := fmt.Errorf("unable to parse fields from zookeeper response (no regex matches)")
 			ss[i] = &ServerStats{Error: err}
 			imOk = false
 			continue
 		}
+
+		match := matches[0][1:]
 
 		// determine current server
 		var srvrMode Mode


### PR DESCRIPTION
Nil pointers are possible in the SRVR four letter word function if the server responds with empty or partial content.