### PR TITLE
return server error on bad multi response header type

### DIFF
--- a/zk/structs.go
+++ b/zk/structs.go
@@ -346,7 +346,7 @@ func (r *multiResponse) Decode(buf []byte) (int, error) {
 		var w reflect.Value
 		switch header.Type {
 		default:
-			return total, ErrAPIError
+			return total, res.Header.Err.toError()
 		case opCreate:
 			w = reflect.ValueOf(&res.String)
 		case opSetData:


### PR DESCRIPTION
Heyo,

When you send a `Multi(...)` request and the response is something like error code -101 (`zk: node does not exist`), the current decoder just returns a generic `ErrAPIError` which is quite confusing, given that the ZK docs say:

> API errors. This is never thrown by the server [...].
https://zookeeper.apache.org/doc/r3.3.3/api/org/apache/zookeeper/KeeperException.Code.html#APIERROR

=P