### PR TITLE
Invalidate all watches is previous watches failed to be sent. Fix #83.

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -392,6 +392,7 @@ func (c *Conn) sendSetWatches() {
 		_, err := c.request(opSetWatches, req, res, nil)
 		if err != nil {
 			c.logger.Printf("Failed to set previous watches: %s", err.Error())
+			c.invalidateWatches(err)
 		}
 	}()
 }


### PR DESCRIPTION
I believe this to be an adequate fix - on this error the application can just retry setting the watches on their own.