### PR TITLE
Connection logic improvements

### DIFF
--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -1,8 +1,7 @@
 package zk
 
 import (
-	"fmt"
-	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -46,62 +45,122 @@ func TestBasicCluster(t *testing.T) {
 	}
 }
 
+// If the current leader dies, then the session is reestablished with the new one.
 func TestClientClusterFailover(t *testing.T) {
-	ts, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	tc, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ts.Stop()
-	zk, evCh, err := ts.ConnectAll()
+	defer tc.Stop()
+	zk, evCh, err := tc.ConnectAll()
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}
 	defer zk.Close()
 
-	hasSession := make(chan string, 1)
-	go func() {
-		for ev := range evCh {
-			if ev.Type == EventSession && ev.State == StateHasSession {
-				select {
-				case hasSession <- ev.Server:
-				default:
-				}
-			}
-		}
-	}()
+	sl := NewStateLogger(evCh)
 
-	waitSession := func() string {
-		select {
-		case srv := <-hasSession:
-			return srv
-		case <-time.After(time.Second * 8):
-			t.Fatal("Failed to connect and get a session")
-		}
-		return ""
+	hasSessionEvent1 := sl.NewWatcher(sessionStateMatcher(StateHasSession)).Wait(8 * time.Second)
+	if hasSessionEvent1 == nil {
+		t.Fatalf("Failed to connect and get session")
 	}
 
-	srv := waitSession()
 	if _, err := zk.Create("/gozk-test", []byte("foo-cluster"), 0, WorldACL(PermAll)); err != nil {
 		t.Fatalf("Create failed on node 1: %+v", err)
 	}
 
-	stopped := false
-	for _, s := range ts.Servers {
-		if strings.HasSuffix(srv, fmt.Sprintf(":%d", s.Port)) {
-			s.Srv.Stop()
-			stopped = true
-			break
-		}
-	}
-	if !stopped {
-		t.Fatal("Failed to stop server")
+	hasSessionWatcher2 := sl.NewWatcher(sessionStateMatcher(StateHasSession))
+
+	// Kill the current leader
+	tc.StopServer(hasSessionEvent1.Server)
+
+	// Wait for the session to be reconnected with the new leader.
+	hasSessionWatcher2.Wait(8 * time.Second)
+	if hasSessionWatcher2 == nil {
+		t.Fatalf("Failover failed")
 	}
 
-	waitSession()
 	if by, _, err := zk.Get("/gozk-test"); err != nil {
 		t.Fatalf("Get failed on node 2: %+v", err)
 	} else if string(by) != "foo-cluster" {
 		t.Fatal("Wrong data for node 2")
+	}
+}
+
+// If a ZooKeeper cluster looses quorum then a session is reconnected as soon
+// as the quorum is restored.
+func TestNoQuorum(t *testing.T) {
+	tc, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tc.Stop()
+	zk, evCh, err := tc.ConnectAllTimeout(4 * time.Second)
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	defer zk.Close()
+	sl := NewStateLogger(evCh)
+
+	// Wait for initial session to be established
+	hasSessionEvent1 := sl.NewWatcher(sessionStateMatcher(StateHasSession)).Wait(8 * time.Second)
+	if hasSessionEvent1 == nil {
+		t.Fatalf("Failed to connect and get session")
+	}
+	initialSessionID := zk.sessionID
+	DefaultLogger.Printf("    Session established: id=%d, timeout=%d", zk.sessionID, zk.sessionTimeoutMs)
+
+	// Kill the ZooKeeper leader and wait for the session to reconnect.
+	DefaultLogger.Printf("    Kill the leader")
+	hasSessionWatcher2 := sl.NewWatcher(sessionStateMatcher(StateHasSession))
+	tc.StopServer(hasSessionEvent1.Server)
+	hasSessionEvent2 := hasSessionWatcher2.Wait(8 * time.Second)
+	if hasSessionEvent2 == nil {
+		t.Fatalf("Failover failed")
+	}
+
+	// Kill the ZooKeeper leader leaving the cluster without quorum.
+	DefaultLogger.Printf("    Kill the leader")
+	tc.StopServer(hasSessionEvent2.Server)
+
+	// Make sure that we keep retrying connecting to the only remaining
+	// ZooKeeper server, but the attempts are being dropped because there is
+	// no quorum.
+	DefaultLogger.Printf("    Retrying no luck...")
+	var firstDisconnect *Event
+	begin := time.Now()
+	for time.Now().Sub(begin) < 6*time.Second {
+		disconnectedEvent := sl.NewWatcher(sessionStateMatcher(StateDisconnected)).Wait(4 * time.Second)
+		if disconnectedEvent == nil {
+			t.Fatalf("Disconnected event expected")
+		}
+		if firstDisconnect == nil {
+			firstDisconnect = disconnectedEvent
+			continue
+		}
+		if disconnectedEvent.Server != firstDisconnect.Server {
+			t.Fatalf("Disconnect from wrong server: expected=%s, actual=%s",
+				firstDisconnect.Server, disconnectedEvent.Server)
+		}
+	}
+
+	// Start a ZooKeeper node to restore quorum.
+	hasSessionWatcher3 := sl.NewWatcher(sessionStateMatcher(StateHasSession))
+	tc.StartServer(hasSessionEvent1.Server)
+
+	// Make sure that session is reconnected with the same ID.
+	hasSessionEvent3 := hasSessionWatcher3.Wait(8 * time.Second)
+	if hasSessionEvent3 == nil {
+		t.Fatalf("Session has not been reconnected")
+	}
+	if zk.sessionID != initialSessionID {
+		t.Fatalf("Wrong session ID: expected=%d, actual=%d", initialSessionID, zk.sessionID)
+	}
+
+	// Make sure that the session is not dropped soon after reconnect
+	e := sl.NewWatcher(sessionStateMatcher(StateDisconnected)).Wait(6 * time.Second)
+	if e != nil {
+		t.Fatalf("Unexpected disconnect")
 	}
 }
 
@@ -162,5 +221,74 @@ func TestBadSession(t *testing.T) {
 
 	if err := zk.Delete("/gozk-test", -1); err != nil && err != ErrNoNode {
 		t.Fatalf("Delete returned error: %+v", err)
+	}
+}
+
+type EventLogger struct {
+	events   []Event
+	watchers []*EventWatcher
+	lock     sync.Mutex
+	wg       sync.WaitGroup
+}
+
+func NewStateLogger(eventCh <-chan Event) *EventLogger {
+	el := &EventLogger{}
+	el.wg.Add(1)
+	go func() {
+		defer el.wg.Done()
+		for event := range eventCh {
+			el.lock.Lock()
+			for _, sw := range el.watchers {
+				if !sw.triggered && sw.matcher(event) {
+					sw.triggered = true
+					sw.matchCh <- event
+				}
+			}
+			DefaultLogger.Printf("    event received: %v\n", event)
+			el.events = append(el.events, event)
+			el.lock.Unlock()
+		}
+	}()
+	return el
+}
+
+func (el *EventLogger) NewWatcher(matcher func(Event) bool) *EventWatcher {
+	ew := &EventWatcher{matcher: matcher, matchCh: make(chan Event, 1)}
+	el.lock.Lock()
+	el.watchers = append(el.watchers, ew)
+	el.lock.Unlock()
+	return ew
+}
+
+func (el *EventLogger) Events() []Event {
+	el.lock.Lock()
+	transitions := make([]Event, len(el.events))
+	copy(transitions, el.events)
+	el.lock.Unlock()
+	return transitions
+}
+
+func (el *EventLogger) Wait4Stop() {
+	el.wg.Wait()
+}
+
+type EventWatcher struct {
+	matcher   func(Event) bool
+	matchCh   chan Event
+	triggered bool
+}
+
+func (ew *EventWatcher) Wait(timeout time.Duration) *Event {
+	select {
+	case event := <-ew.matchCh:
+		return &event
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+func sessionStateMatcher(s State) func(Event) bool {
+	return func(e Event) bool {
+		return e.Type == EventSession && e.State == s
 	}
 }

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -224,9 +224,9 @@ func (c *Conn) setState(state State) {
 }
 
 func (c *Conn) connect() error {
-	c.setState(StateConnecting)
 	for {
 		c.serverIndex = (c.serverIndex + 1) % len(c.servers)
+		c.setState(StateConnecting)
 		if c.serverIndex == c.lastServerIndex {
 			c.flushUnsentRequests(ErrNoServer)
 			select {

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -294,6 +294,7 @@ func (c *Conn) loop() {
 				wg.Done()
 			}()
 
+			c.sendSetWatches()
 			wg.Wait()
 		}
 
@@ -425,8 +426,6 @@ func (c *Conn) authenticate() error {
 	if err != nil {
 		return err
 	}
-
-	c.sendSetWatches()
 
 	// connect response
 

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -88,7 +89,7 @@ func StartTestCluster(size int, stdout, stderr io.Writer) (*TestCluster, error) 
 		})
 	}
 	success = true
-	time.Sleep(time.Second) // Give the server time to become active. Should probably actually attempt to connect to verify.
+	time.Sleep(3 * time.Second) // Give the server time to become active. Should probably actually attempt to connect to verify.
 	return cluster, nil
 }
 
@@ -116,4 +117,24 @@ func (ts *TestCluster) Stop() error {
 	}
 	defer os.RemoveAll(ts.Path)
 	return nil
+}
+
+func (tc *TestCluster) StartServer(server string) {
+	for _, s := range tc.Servers {
+		if strings.HasSuffix(server, fmt.Sprintf(":%d", s.Port)) {
+			s.Srv.Start()
+			return
+		}
+	}
+	panic(fmt.Sprintf("Unknown server: %s", server))
+}
+
+func (tc *TestCluster) StopServer(server string) {
+	for _, s := range tc.Servers {
+		if strings.HasSuffix(server, fmt.Sprintf(":%d", s.Port)) {
+			s.Srv.Stop()
+			return
+		}
+	}
+	panic(fmt.Sprintf("Unknown server: %s", server))
 }

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -297,10 +297,12 @@ func TestSetWatchers(t *testing.T) {
 		t.Fatal("Children should return at least 1 child")
 	}
 
+	// Simulate network error by brutally closing the network connection.
 	zk.conn.Close()
 	if err := zk2.Delete(testPath, -1); err != nil && err != ErrNoNode {
 		t.Fatalf("Delete returned error: %+v", err)
 	}
+	// Allow some time for the `zk` session to reconnect and set watches.
 	time.Sleep(time.Millisecond * 100)
 
 	if path, err := zk2.Create("/gozk-test", []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {


### PR DESCRIPTION
This PR brings several improvements and fixes that we made in the connection object implementation to address issues that had been discovered while running the library in production. They are as follows:

* `recvTimeout`, `pingTimeout` derive from session timeout and therefore should be recalculated if a new sessionTimeout value is negotiated; 
* make logging of the connection life cycle state transitions a bit more verbose to facilitate connection issue debugging;
* watches should be restored on successful authentication only;
* the server connection string reported in **connecting** event was incorrect;
* session information should not be discarded on connection errors. It is better to spin in the connect/disconnect loop until ZooKeeper cluster recovers then to drop a legit session data.  

If you think that these changes should be separated into different commits then let me know. Although some of them just one liners, and the majority of changes were made to write NoQuorum test anyways.