### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: go
 go:
   - 1.4.2
 
-sudo: false
-
 branches:
   only:
     - master
@@ -12,10 +10,10 @@ before_install:
   - wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
   - tar -zxvf zookeeper*tar.gz
 
+install:
+  - go get -t ./...
+
 script:
   - go build ./...
-  - go fmt ./...
-  - go get golang.org/x/tools/cmd/vet
   - go vet ./...
-  - go test -i -race ./...
   - go test -v -race ./...

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"camlistore.org/pkg/throttle"
+	"go4.org/net/throttle"
 )
 
 func TestCreate(t *testing.T) {


### PR DESCRIPTION
Travis build is broken, and a test package was moved to a new URL.

- various issues with ``travis.yml``, fixed by @tevino
- package "camlistore.org/pkg/throttle" moved to "go4.org/net/throttle"