### PR TITLE
Allocate an extra 16 bytes in the buffer

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -578,8 +578,8 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 		}
 
 		blen := int(binary.BigEndian.Uint32(buf[:4]))
-		if cap(buf) < blen {
-			buf = make([]byte, blen)
+		if cap(buf) < (blen + 16) {
+			buf = make([]byte, blen + 16)
 		}
 
 		_, err = io.ReadFull(conn, buf[:blen])


### PR DESCRIPTION
When we need to resize the current buffer because
our packet is too large, we need to account for
the fact that we expect 16 bytes more than `blen`
to be available for parsing.

Otherwise, this line:

```go
_, err := decodePacket(buf[16:16+blen], res)
```

cannot possibly work without an array index error.

We ran into this with vault getting the following error:

```
panic: runtime error: slice bounds out of range

goroutine 25 [running]:
panic(0x11f31a0, 0xc8200100d0)
        /goroot/src/runtime/panic.go:464 +0x3e6
github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk.(*Conn).recvLoop(0xc8201f80e0, 0x7f469e1473c8, 0xc820024180, 0x0, 0x0)
        /gopath/src/github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk/conn.go:656 +0x1290
github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk.(*Conn).loop.func2(0xc8201f80e0, 0xc8202e6000, 0xc8204981f0)
        /gopath/src/github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk/conn.go:325 +0x51
created by github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk.(*Conn).loop
        /gopath/src/github.com/hashicorp/vault/vendor/github.com/samuel/go-zookeeper/zk/conn.go:332 +0x844
```

Feedback would be appreciated!