### PR TITLE
Fix buffer index panic when custom buffer length is needed

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -579,7 +579,7 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 
 		blen := int(binary.BigEndian.Uint32(buf[:4]))
 		if cap(buf) < blen {
-			buf = make([]byte, blen)
+			buf = make([]byte, 16+blen)
 		}
 
 		_, err = io.ReadFull(conn, buf[:blen])


### PR DESCRIPTION
When deleting 100,000 znodes at a time, the stock 1.5MB buffer is insufficient and a custom buffer length is assigned.  However, in these cases, the final buffer read panics due to an improperly-sized buffer.