### PR TITLE
Add RO mode compatibilty

### DIFF
--- a/zk/structs.go
+++ b/zk/structs.go
@@ -148,6 +148,7 @@ type connectRequest struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	RO              bool
 }
 
 type connectResponse struct {
@@ -155,6 +156,7 @@ type connectResponse struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	RO              bool
 }
 
 type CreateRequest struct {


### PR DESCRIPTION
The read only mode field should be send directly in the connect request
and response. fixes #86 

This PR does not change the behaviour of the client api, just add compatibility
