### PR TITLE
Re-submit authentication data on reconnect

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -100,6 +100,8 @@ type Conn struct {
 	reconnectDelay time.Duration
 
 	logger Logger
+
+	buf []byte
 }
 
 // connOption represents a connection option.
@@ -195,6 +197,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 		watchers:       make(map[watchPathType][]chan Event),
 		passwd:         emptyPassword,
 		logger:         DefaultLogger,
+		buf:            make([]byte, bufferSize),
 
 		// Debug
 		reconnectDelay: 0,
@@ -601,16 +604,14 @@ func (c *Conn) authenticate() error {
 }
 
 func (c *Conn) sendData(req *request) error {
-	buf := make([]byte, bufferSize)
-
 	header := &requestHeader{req.xid, req.opcode}
-	n, err := encodePacket(buf[4:], header)
+	n, err := encodePacket(c.buf[4:], header)
 	if err != nil {
 		req.recvChan <- response{-1, err}
 		return nil
 	}
 
-	n2, err := encodePacket(buf[4+n:], req.pkt)
+	n2, err := encodePacket(c.buf[4+n:], req.pkt)
 	if err != nil {
 		req.recvChan <- response{-1, err}
 		return nil
@@ -618,7 +619,7 @@ func (c *Conn) sendData(req *request) error {
 
 	n += n2
 
-	binary.BigEndian.PutUint32(buf[:4], uint32(n))
+	binary.BigEndian.PutUint32(c.buf[:4], uint32(n))
 
 	c.requestsLock.Lock()
 	select {
@@ -632,7 +633,7 @@ func (c *Conn) sendData(req *request) error {
 	c.requestsLock.Unlock()
 
 	c.conn.SetWriteDeadline(time.Now().Add(c.recvTimeout))
-	_, err = c.conn.Write(buf[:n+4])
+	_, err = c.conn.Write(c.buf[:n+4])
 	c.conn.SetWriteDeadline(time.Time{})
 	if err != nil {
 		req.recvChan <- response{-1, err}
@@ -647,7 +648,6 @@ func (c *Conn) sendLoop() error {
 	pingTicker := time.NewTicker(c.pingInterval)
 	defer pingTicker.Stop()
 
-	buf := make([]byte, bufferSize)
 	for {
 		select {
 		case req := <-c.sendChan:
@@ -655,15 +655,15 @@ func (c *Conn) sendLoop() error {
 				return err
 			}
 		case <-pingTicker.C:
-			n, err := encodePacket(buf[4:], &requestHeader{Xid: -2, Opcode: opPing})
+			n, err := encodePacket(c.buf[4:], &requestHeader{Xid: -2, Opcode: opPing})
 			if err != nil {
 				panic("zk: opPing should never fail to serialize")
 			}
 
-			binary.BigEndian.PutUint32(buf[:4], uint32(n))
+			binary.BigEndian.PutUint32(c.buf[:4], uint32(n))
 
 			c.conn.SetWriteDeadline(time.Now().Add(c.recvTimeout))
-			_, err = c.conn.Write(buf[:n+4])
+			_, err = c.conn.Write(c.buf[:n+4])
 			c.conn.SetWriteDeadline(time.Time{})
 			if err != nil {
 				c.conn.Close()

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -192,3 +192,25 @@ func (tc *TestCluster) StopServer(server string) {
 	}
 	panic(fmt.Sprintf("Unknown server: %s", server))
 }
+
+func (tc *TestCluster) StartAllServers() error {
+	for _, s := range tc.Servers {
+		if err := s.Srv.Start(); err != nil {
+			return fmt.Errorf(
+				"Failed to start server listening on port `%d` : %+v", s.Port, err)
+		}
+	}
+
+	return nil
+}
+
+func (tc *TestCluster) StopAllServers() error {
+	for _, s := range tc.Servers {
+		if err := s.Srv.Stop(); err != nil {
+			return fmt.Errorf(
+				"Failed to stop server listening on port `%d` : %+v", s.Port, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
In case when reconnection occurs, it is necessary to re-authenticate with ZK because it "forgets" the authentication data. Otherwise, the connection is unusable with messages like below popping up in the logs:
```
2016/08/29 12:08:36 [ERR] core: failed to write seal configuration: zk: not authenticated
2016/08/29 12:08:46 [ERR] core: failed to write seal configuration: zk: not authenticated
2016/08/29 12:08:56 [ERR] core: failed to write seal configuration: zk: not authenticated
```

The problem can be reproduced with this simple program:
```go
package main

import (
	"fmt"
	"time"

	"github.com/samuel/go-zookeeper/zk"
)

func main() {
	c, _, err := zk.Connect([]string{"127.0.0.1"}, time.Second) //*10)
	if err != nil {
		panic(err)
	}
	defer c.Close()

	for c.State() != zk.StateHasSession {
		fmt.Println("State: ", c.State())
		time.Sleep(time.Second)
	}
	fmt.Printf("Connected to %s\n", c.Server())

	c.AddAuth("digest", []byte("userfoo:passbar"))

	acl := zk.DigestACL(zk.PermAll, "userfoo", "passbar")

	_, err = c.Create("/dir", nil, 0, acl)
	if err != nil && err != zk.ErrNodeExists {
		panic(err)
	}

	for {
		res_path, err := c.Create("/dir/dupa", []byte("maryna"), zk.FlagEphemeral|zk.FlagSequence, acl)
		if err != nil {
			fmt.Printf("Error creating ephemeral node: %s\n", err)
		} else {
			fmt.Printf("Created node %s\n", res_path)
		}
		time.Sleep(time.Second)
	}
}

```

One only needs to block tcp port 2181 traffic or pause/unpause ZK container/process.

I have not found official ZK protocol specification but instead based my work on what ZK Python client `Kazoo` does: https://github.com/python-zk/kazoo/blob/master/kazoo/client.py#L722 The change basically stores all submitted auth credentials in connection structure, and on reconnect the sendLoop is stalled until all authentication data has been resubmitted. The re-submission happens synchronously, without involving sendLoop. After all data has been submitted, send loop starts and submits all queued requests. The recieveLoop is unchanged due to the fact that outstanding responses are purged on reconnect.

This patch may probably be still improved (not re-submitting the same auth data, de-duplicating auth data for `digest` schema, etc...) and I am not sure if this is the right approach, but I think this is a step into right direction :)

I would be grateful for feedback.

Thanks!
pr