### PR TITLE
Fix test that was not properly shutting down server. 

### DIFF
--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -94,7 +94,10 @@ var jarSearchPaths = []string{
 func findZookeeperFatJar() string {
 	var paths []string
 	zkPath := os.Getenv("ZOOKEEPER_PATH")
-	if zkPath == "" {
+	zkJarPath := os.Getenv("ZOOKEEPER_JARPATH")
+	if zkJarPath != "" {
+		paths = []string{zkJarPath}
+	} else if zkPath == "" {
 		paths = jarSearchPaths
 	} else {
 		paths = []string{filepath.Join(zkPath, "contrib/fatjar/zookeeper-*-fatjar.jar")}

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -134,6 +134,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ts.Stop()
 
 	zk, _, err := ts.ConnectAll()
 	if err != nil {


### PR DESCRIPTION
Also allow direct injection of Zookeeper jar file. This helps when testing a precise version of the server - say 3.4.8 vs 3.5.2.

Hopefully I've gotten the hang of pull requests.