### PR TITLE
Add support for Create2 which returns the Stat struct on success.

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -886,6 +886,16 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 	return res.Path, err
 }
 
+// Return Stat data for the created node.
+func (c *Conn) Create2(path string, data []byte, flags int32, acl []ACL) (string, *Stat, error) {
+	res := &create2Response{}
+	_, err := c.request(opCreate2, &CreateRequest{path, data, acl, flags}, res, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	return res.Path, &res.Stat, err
+}
+
 // CreateProtectedEphemeralSequential fixes a race condition if the server crashes
 // after it creates the node. On reconnect the session may still be valid so the
 // ephemeral node still exists. Therefore, on reconnect we need to check if a node

--- a/zk/constants.go
+++ b/zk/constants.go
@@ -2,6 +2,7 @@ package zk
 
 import (
 	"errors"
+	"fmt"
 )
 
 const (
@@ -11,24 +12,33 @@ const (
 )
 
 const (
-	opNotify       = 0
-	opCreate       = 1
-	opDelete       = 2
-	opExists       = 3
-	opGetData      = 4
-	opSetData      = 5
-	opGetAcl       = 6
-	opSetAcl       = 7
-	opGetChildren  = 8
-	opSync         = 9
-	opPing         = 11
-	opGetChildren2 = 12
-	opCheck        = 13
-	opMulti        = 14
-	opClose        = -11
-	opSetAuth      = 100
-	opSetWatches   = 101
-	opError        = -1
+	opNotify          = 0
+	opCreate          = 1
+	opDelete          = 2
+	opExists          = 3
+	opGetData         = 4
+	opSetData         = 5
+	opGetAcl          = 6
+	opSetAcl          = 7
+	opGetChildren     = 8
+	opSync            = 9
+	opPing            = 11
+	opGetChildren2    = 12
+	opCheck           = 13
+	opMulti           = 14
+	opCreate2         = 15
+	opReconfig        = 16
+	opCheckWatches    = 17
+	opRemoveWatches   = 18
+	opCreateContainer = 19
+	opDeleteContainer = 20
+	opSetAuth         = 100
+	opSetWatches      = 101
+	sasl              = 102
+	opCreateSession   = -10
+	opClose           = -11
+	opCloseSession    = -11
+	opError           = -1
 	// Not in protocol, used internally
 	opWatcherEvent = -2
 )
@@ -111,8 +121,12 @@ var (
 	ErrInvalidACL              = errors.New("zk: invalid ACL specified")
 	ErrAuthFailed              = errors.New("zk: client authentication failed")
 	ErrClosing                 = errors.New("zk: zookeeper is closing")
-	ErrNothing                 = errors.New("zk: no server responsees to process")
+	ErrNothing                 = errors.New("zk: no server responses to process")
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
+	ErrNotReadOnly             = errors.New("zk: write operation on read-only session")
+	ErrEphemeralOnLocalSession = errors.New("zk: ephemeral on local session")
+	ErrNoWatcher               = errors.New("zk: no such watcher")
+	ErrUnimplemented           = errors.New("zk: unimplemented")
 
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 	errCodeToError = map[ErrCode]error{
@@ -126,11 +140,15 @@ var (
 		errNotEmpty:                ErrNotEmpty,
 		errSessionExpired:          ErrSessionExpired,
 		// errInvalidCallback:         ErrInvalidCallback,
-		errInvalidAcl:   ErrInvalidACL,
-		errAuthFailed:   ErrAuthFailed,
-		errClosing:      ErrClosing,
-		errNothing:      ErrNothing,
-		errSessionMoved: ErrSessionMoved,
+		errInvalidAcl:              ErrInvalidACL,
+		errAuthFailed:              ErrAuthFailed,
+		errClosing:                 ErrClosing,
+		errNothing:                 ErrNothing,
+		errSessionMoved:            ErrSessionMoved,
+		errNoWatcher:               ErrNoWatcher,
+		errEphemeralOnLocalSession: ErrEphemeralOnLocalSession,
+		errNotReadOnly:             ErrNotReadOnly,
+		errUnimplemented:           ErrUnimplemented,
 	}
 )
 
@@ -138,7 +156,7 @@ func (e ErrCode) toError() error {
 	if err, ok := errCodeToError[e]; ok {
 		return err
 	}
-	return ErrUnknown
+	return fmt.Errorf("%v: %v", ErrUnknown, e)
 }
 
 const (
@@ -168,6 +186,9 @@ const (
 	errClosing                 ErrCode = -116
 	errNothing                 ErrCode = -117
 	errSessionMoved            ErrCode = -118
+	errNotReadOnly             ErrCode = -119
+	errEphemeralOnLocalSession ErrCode = -120
+	errNoWatcher               ErrCode = -121
 )
 
 // Constants for ACL permissions

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -136,6 +136,11 @@ type statResponse struct {
 	Stat Stat
 }
 
+type create2Response struct {
+	Path string
+	Stat Stat
+}
+
 //
 
 type CheckVersionRequest PathVersionRequest
@@ -357,6 +362,10 @@ func (r *multiResponse) Decode(buf []byte) (int, error) {
 		case opSetData:
 			res.Stat = new(Stat)
 			w = reflect.ValueOf(res.Stat)
+		case opCreate2:
+			w = reflect.ValueOf(&res.String)
+			res.Stat = new(Stat)
+			w = reflect.ValueOf(res.Stat)
 		case opCheck, opDelete:
 		}
 		if w.IsValid() {
@@ -574,7 +583,7 @@ func requestStructForOp(op int32) interface{} {
 	switch op {
 	case opClose:
 		return &closeRequest{}
-	case opCreate:
+	case opCreate, opCreate2:
 		return &CreateRequest{}
 	case opDelete:
 		return &DeleteRequest{}

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -70,14 +70,41 @@ func TestCreate(t *testing.T) {
 	defer zk.Close()
 
 	path := "/gozk-test"
+	path2 := path + "2"
 
 	if err := zk.Delete(path, -1); err != nil && err != ErrNoNode {
 		t.Fatalf("Delete returned error: %+v", err)
 	}
+
 	if p, err := zk.Create(path, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
 		t.Fatalf("Create returned error: %+v", err)
 	} else if p != path {
 		t.Fatalf("Create returned different path '%s' != '%s'", p, path)
+	}
+
+	// Zookeeper 3.5.x releases support a more fully featured create2
+	// operation that is not backward compatible. Assume any test
+	// cluster is homogenous and check only the first instance.
+	srvrStats, ok := FLWSrvr([]string{fmt.Sprintf("localhost:%v", ts.Servers[0].Port)}, 500*time.Millisecond)
+	if !ok {
+		t.Fatalf("FLWSrvr failed error: %v", srvrStats[0].Error)
+	}
+
+	if strings.HasPrefix(srvrStats[0].Version, "3.5.") {
+		if p, stat, err := zk.Create2(path2, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+			t.Fatalf("Create returned error: %+v", err)
+		} else if p != path2 {
+			t.Fatalf("Create returned different path '%s' != '%s'", p, path2)
+		} else if stat.Czxid == 0 || stat.Mzxid == 0 {
+			t.Fatalf("Create returned invalid stat czxid:0x%X mzxid:0x%X", stat.Czxid, stat.Mzxid)
+		}
+		if p, stat, err := zk.Create2(path2, nil, 0, WorldACL(PermAll)); err == nil {
+			t.Fatalf("Create should have failed with NodeExists")
+		} else if stat != nil {
+			t.Fatalf("Create should have returned nil stat on failure.")
+		} else if p != "" {
+			t.Fatalf("Create should have returned empty path on failure.")
+		}
 	}
 	if data, stat, err := zk.Get(path); err != nil {
 		t.Fatalf("Get returned error: %+v", err)
@@ -86,6 +113,7 @@ func TestCreate(t *testing.T) {
 	} else if len(data) < 4 {
 		t.Fatal("Get returned wrong size data")
 	}
+
 }
 
 func TestMulti(t *testing.T) {


### PR DESCRIPTION
Add new op and error code.

Implement Create2 as a separate call since it is not backward compatible.

Note that this requires version 3.5.x of the server to exercise the test cases.