### PR TITLE
fix spin in (*Lock).Lock()

### DIFF
--- a/zk/lock.go
+++ b/zk/lock.go
@@ -94,7 +94,7 @@ func (l *Lock) Lock() error {
 		}
 
 		lowestSeq := seq
-		prevSeq := 0
+		prevSeq := -1
 		prevSeqPath := ""
 		for _, p := range children {
 			s, err := parseSeq(p)


### PR DESCRIPTION
Consider the case where there are two clients contending for a lock.
The first creates  '/lock/00000'
The second creates '/lock/00001'

Now, the first lists the children of '/lock' and sees that it has
created the lock and returns.

The second starts looping through the children in the aforementioned order.
Before the first child is processed we have
lowestSeq=1
prevSeq=0
prevSeqPath=""

Since the first child is '00000' we set lowestSeq=0.
However, prevSeq == s, so the second condition fails and
we don't update the prevSeqPath.

Then we process '00001' and again, since s == seq, so !(s<seq), we again
don't update prevSeqPath.

This leads to a scenario where lowerdown we call GetW("/lock/") instead of GetW("/lock/00000"), which fails with ErrNoNode, which continues the loop and we're stuck, spinning as fast as zookeeper can go.