### PR TITLE
Fix ChidlrenW doesn't work the same as the java client

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -719,7 +719,9 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 			switch res.Type {
 			case EventNodeCreated:
 				wTypes = append(wTypes, watchTypeExist)
-			case EventNodeDeleted, EventNodeDataChanged:
+			case EventNodeDataChanged:
+				wTypes = append(wTypes, watchTypeExist, watchTypeData)
+			case EventNodeDeleted:
 				wTypes = append(wTypes, watchTypeExist, watchTypeData, watchTypeChild)
 			case EventNodeChildrenChanged:
 				wTypes = append(wTypes, watchTypeChild)


### PR DESCRIPTION
ChildrenW's events should't  have  `NodeDataChanged`

https://github.com/apache/zookeeper/blob/master/src/java/main/org/apache/zookeeper/ZooKeeper.java#L486