### PR TITLE
break up set-watches on reconnect into multiple packets

### DIFF
--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -75,8 +75,7 @@ func TestClientClusterFailover(t *testing.T) {
 	tc.StopServer(hasSessionEvent1.Server)
 
 	// Wait for the session to be reconnected with the new leader.
-	hasSessionWatcher2.Wait(8 * time.Second)
-	if hasSessionWatcher2 == nil {
+	if hasSessionWatcher2.Wait(8*time.Second) == nil {
 		t.Fatalf("Failover failed")
 	}
 


### PR DESCRIPTION
This fixes an issue wherein a client that has a very large number of watches (and/or very long path names that are being watched) could cause a disconnect to be effectively permanent: the client gets stuck in a loop of trying to reconnect but being continually disconnected by the server.

This happens because the client may try to construct a request that is too large for the server to process. A ZK server, by default, limits incoming requests to 1mb. The hard-coded request buffer size in this client is 1.5mb.

It also fixes a related possible bug where the connection is successfully re-established, but watches are silently lost (because the set-watches request is so big it results in `ErrShortBuffer` when trying to encode the set-watches-request packet).