### PR TITLE
Continue on DNS lookup failure

### DIFF
--- a/zk/dnshostprovider.go
+++ b/zk/dnshostprovider.go
@@ -38,7 +38,7 @@ func (hp *DNSHostProvider) Init(servers []string) error {
 		}
 		addrs, err := lookupHost(host)
 		if err != nil {
-			return err
+			continue
 		}
 		for _, addr := range addrs {
 			found = append(found, net.JoinHostPort(addr, port))

--- a/zk/dnshostprovider_test.go
+++ b/zk/dnshostprovider_test.go
@@ -50,6 +50,24 @@ func TestDNSHostProviderCreate(t *testing.T) {
 	}
 }
 
+func TestDNSHostProviderFailedLookup(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	port := ts.Servers[0].Port
+	unknownServer := fmt.Sprintf("unknown.example.com:%d", port)
+	knownServer := fmt.Sprintf("foo.example.com:%d", port)
+	hostProvider := &DNSHostProvider{lookupHost: localhostLookupHost}
+	zk, _, err := Connect([]string{unknownServer, knownServer}, time.Second*15, WithHostProvider(hostProvider))
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	zk.Close()
+}
+
 // localHostPortsFacade wraps a HostProvider, remapping the
 // address/port combinations it returns to "localhost:$PORT" where
 // $PORT is chosen from the provided ports.


### PR DESCRIPTION
Today, a single failed DNS lookup prevents the client from connecting to the Zookeeper cluster. Instead, a failed DNS lookup should be treated like a down node. In other words, it should ignore the failure and try connecting to the rest of the nodes.

@samuel for review