### PR TITLE
Adding ZK 3.5 reconfig APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+.vscode/
 .DS_Store
+profile.cov
+zookeeper
+zookeeper-*/
+zookeeper-*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 go:
+  - 1.11
   - 1.9
+  - tip
+
+go_import_path: github.com/samuel/go-zookeeper
 
 jdk:
   - oraclejdk9
@@ -10,24 +14,29 @@ sudo: false
 branches:
   only:
     - master
+    - dev
 
 before_install:
-  - wget http://apache.cs.utah.edu/zookeeper/zookeeper-${zk_version}/zookeeper-${zk_version}.tar.gz
-  - tar -zxvf zookeeper*tar.gz && zip -d zookeeper-${zk_version}/contrib/fatjar/zookeeper-${zk_version}-fatjar.jar 'META-INF/*.SF' 'META-INF/*.DSA'
-  - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
+  - make travis ZK_VERSION=${zk_version}
+
+before_script:
+  - go vet ./...
+  - go fmt ./...
 
 script:
   - jdk_switcher use oraclejdk9
   - go build ./...
-  - go fmt ./...
-  - go vet ./...
-  - go test -i -race ./...
-  - go test -race -covermode atomic -coverprofile=profile.cov ./zk
-  - goveralls -coverprofile=profile.cov -service=travis-ci
+  - make test
+
+matrix:
+  allow_failures:
+    - go: tip
+    - env: zk_version=3.5.4-beta
+  fast_finish: true
 
 env:
   global:
     secure: Coha3DDcXmsekrHCZlKvRAc+pMBaQU1QS/3++3YCCUXVDBWgVsC1ZIc9df4RLdZ/ncGd86eoRq/S+zyn1XbnqK5+ePqwJoUnJ59BE8ZyHLWI9ajVn3fND1MTduu/ksGsS79+IYbdVI5wgjSgjD3Ktp6Y5uPl+BPosjYBGdNcHS4=
   matrix:
-    - zk_version=3.4.10
+    - zk_version=3.5.4-beta
+    - zk_version=3.4.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,20 @@ sudo: false
 branches:
   only:
     - master
-    - dev
 
 before_install:
-  - make travis ZK_VERSION=${zk_version}
+  - make setup ZK_VERSION=${zk_version}
 
 before_script:
-  - go vet ./...
-  - go fmt ./...
+  - make lint
 
 script:
   - jdk_switcher use oraclejdk9
-  - go build ./...
-  - make test
+  - make
 
 matrix:
   allow_failures:
     - go: tip
-    - env: zk_version=3.5.4-beta
   fast_finish: true
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ ZK_VERSION ?= 3.4.12
 ZK = zookeeper-$(ZK_VERSION)
 ZK_URL = "https://archive.apache.org/dist/zookeeper/$(ZK)/$(ZK).tar.gz"
 
+PACKAGES := $(shell go list ./... | grep -v examples)
+
+.DEFAULT_GOAL := test
+
 $(ZK):
 	wget $(ZK_URL)
 	tar -zxf $(ZK).tar.gz
@@ -11,19 +15,25 @@ $(ZK):
 	# in the test code. this allows backward compatable testing.
 	ln -s $(ZK) zookeeper
 
-
-.PHONY: install-test-deps
-install-test-deps:
+.PHONY: install-covertools
+install-covertools:
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cmd/cover
 
-.PHONY: travis
-travis: $(ZK) install-test-deps
+.PHONY: setup
+setup: $(ZK) install-covertools
+
+.PHONY: lint
+lint:
+	go fmt ./...
+	go vet ./...
+
+.PHONY: build
+build:
+	go build ./...
 
 .PHONY: test
-test:
-	go test -timeout 300s -v ./...
-	go test -timeout 400s -v -i -race ./...
-	go test -timeout 400s -v -race -covermode atomic -coverprofile=profile.cov ./zk
+test: build
+	go test -timeout 500s -v -race -covermode atomic -coverprofile=profile.cov $(PACKAGES)
 	# ignore if we fail to publish coverage
 	-goveralls -coverprofile=profile.cov -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# make file to hold the logic of build and test setup
+ZK_VERSION ?= 3.4.12
+
+ZK = zookeeper-$(ZK_VERSION)
+ZK_URL = "https://archive.apache.org/dist/zookeeper/$(ZK)/$(ZK).tar.gz"
+
+$(ZK):
+	wget $(ZK_URL)
+	tar -zxf $(ZK).tar.gz
+	# we link to a standard directory path so then the tests dont need to find based on version
+	# in the test code. this allows backward compatable testing.
+	ln -s $(ZK) zookeeper
+
+
+.PHONY: install-test-deps
+install-test-deps:
+	go get github.com/mattn/goveralls
+	go get golang.org/x/tools/cmd/cover
+
+.PHONY: travis
+travis: $(ZK) install-test-deps
+
+.PHONY: test
+test:
+	go test -timeout 300s -v ./...
+	go test -timeout 400s -v -i -race ./...
+	go test -timeout 400s -v -race -covermode atomic -coverprofile=profile.cov ./zk
+	# ignore if we fail to publish coverage
+	-goveralls -coverprofile=profile.cov -service=travis-ci

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -22,12 +22,12 @@ func TestBasicCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
-	zk1, err := ts.Connect(0)
+	zk1, _, err := ts.Connect(0)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}
 	defer zk1.Close()
-	zk2, err := ts.Connect(1)
+	zk2, _, err := ts.Connect(1)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}
@@ -191,7 +191,7 @@ func TestWaitForClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
-	zk, err := ts.Connect(0)
+	zk, _, err := ts.Connect(0)
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)
 	}

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -17,7 +17,7 @@ func (lw logWriter) Write(b []byte) (int, error) {
 }
 
 func TestBasicCluster(t *testing.T) {
-	ts, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,6 +38,7 @@ func TestBasicCluster(t *testing.T) {
 	if _, err := zk1.Create("/gozk-test", []byte("foo-cluster"), 0, WorldACL(PermAll)); err != nil {
 		t.Fatalf("Create failed on node 1: %+v", err)
 	}
+
 	if by, _, err := zk2.Get("/gozk-test"); err != nil {
 		t.Fatalf("Get failed on node 2: %+v", err)
 	} else if string(by) != "foo-cluster" {
@@ -47,7 +48,7 @@ func TestBasicCluster(t *testing.T) {
 
 // If the current leader dies, then the session is reestablished with the new one.
 func TestClientClusterFailover(t *testing.T) {
-	tc, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	tc, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +90,7 @@ func TestClientClusterFailover(t *testing.T) {
 // If a ZooKeeper cluster looses quorum then a session is reconnected as soon
 // as the quorum is restored.
 func TestNoQuorum(t *testing.T) {
-	tc, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	tc, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +186,7 @@ func TestNoQuorum(t *testing.T) {
 }
 
 func TestWaitForClose(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +222,7 @@ CONNECTED:
 }
 
 func TestBadSession(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -1223,7 +1223,6 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 // IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
 // by lists of members.
 // Return the new configuration stats.
-// TODO: expose and return the config znode itself like the Java client does.
 func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*Stat, error) {
 	// TODO: validate the shape of the member string to give early feedback.
 	request := &reconfigRequest{
@@ -1238,7 +1237,6 @@ func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*S
 // Reconfig is the non-incremental update functionality for Zookeeper where the list preovided
 // is the entire new member list.
 // the optional version allows for conditional reconfigurations, -1 ignores the condition.
-// TODO: expose and return the config znode itself like the Java client does.
 func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
 	request := &reconfigRequest{
 		NewMembers:  []byte(strings.Join(members, ",")),

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -409,13 +409,11 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 	defer close(reauthReadyChan)
 
 	if c.logInfo {
-		c.logger.Printf("Re-submitting `%d` credentials after reconnect",
-			len(c.creds))
+		c.logger.Printf("re-submitting `%d` credentials after reconnect", len(c.creds))
 	}
 
 	for _, cred := range c.creds {
 		if shouldCancel() {
-			c.logger.Printf("Cancel rer-submitting credentials")
 			return
 		}
 		resChan, err := c.sendRequest(
@@ -428,7 +426,7 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 			nil)
 
 		if err != nil {
-			c.logger.Printf("Call to sendRequest failed during credential resubmit: %s", err)
+			c.logger.Printf("call to sendRequest failed during credential resubmit: %s", err)
 			// FIXME(prozlach): lets ignore errors for now
 			continue
 		}
@@ -437,14 +435,14 @@ func (c *Conn) resendZkAuth(reauthReadyChan chan struct{}) {
 		select {
 		case res = <-resChan:
 		case <-c.closeChan:
-			c.logger.Printf("Recv closed, cancel re-submitting credentials")
+			c.logger.Printf("recv closed, cancel re-submitting credentials")
 			return
 		case <-c.shouldQuit:
-			c.logger.Printf("Should quit, cancel re-submitting credentials")
+			c.logger.Printf("should quit, cancel re-submitting credentials")
 			return
 		}
 		if res.err != nil {
-			c.logger.Printf("Credential re-submit failed: %s", res.err)
+			c.logger.Printf("credential re-submit failed: %s", res.err)
 			// FIXME(prozlach): lets ignore errors for now
 			continue
 		}
@@ -486,14 +484,14 @@ func (c *Conn) loop() {
 		err := c.authenticate()
 		switch {
 		case err == ErrSessionExpired:
-			c.logger.Printf("Authentication failed: %s", err)
+			c.logger.Printf("authentication failed: %s", err)
 			c.invalidateWatches(err)
 		case err != nil && c.conn != nil:
-			c.logger.Printf("Authentication failed: %s", err)
+			c.logger.Printf("authentication failed: %s", err)
 			c.conn.Close()
 		case err == nil:
 			if c.logInfo {
-				c.logger.Printf("Authenticated: id=%d, timeout=%d", c.SessionID(), c.sessionTimeoutMs)
+				c.logger.Printf("authenticated: id=%d, timeout=%d", c.SessionID(), c.sessionTimeoutMs)
 			}
 			c.hostProvider.Connected()        // mark success
 			c.closeChan = make(chan struct{}) // channel to tell send loop stop
@@ -508,7 +506,7 @@ func (c *Conn) loop() {
 				}
 				err := c.sendLoop()
 				if err != nil || c.logInfo {
-					c.logger.Printf("Send loop terminated: err=%v", err)
+					c.logger.Printf("send loop terminated: err=%v", err)
 				}
 				c.conn.Close() // causes recv loop to EOF/exit
 				wg.Done()
@@ -523,7 +521,7 @@ func (c *Conn) loop() {
 					err = c.recvLoop(c.conn)
 				}
 				if err != io.EOF || c.logInfo {
-					c.logger.Printf("Recv loop terminated: err=%v", err)
+					c.logger.Printf("recv loop terminated: err=%v", err)
 				}
 				if err == nil {
 					panic("zk: recvLoop should never return nil error")
@@ -823,10 +821,12 @@ func (c *Conn) recvLoop(conn net.Conn) error {
 	buf := make([]byte, sz)
 	for {
 		// package length
-		conn.SetReadDeadline(time.Now().Add(c.recvTimeout))
+		if err := conn.SetReadDeadline(time.Now().Add(c.recvTimeout)); err != nil {
+			c.logger.Printf("failed to set connection deadline: %v", err)
+		}
 		_, err := io.ReadFull(conn, buf[:4])
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to read from connection: %v", err)
 		}
 
 		blen := int(binary.BigEndian.Uint32(buf[:4]))
@@ -1218,6 +1218,40 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 		mr[i] = MultiResponse{Stat: op.Stat, String: op.String, Error: op.Err.toError()}
 	}
 	return mr, err
+}
+
+// IncrementalReconfig is the zookeeper reconfiguration api that allows adding and removing servers
+// by lists of members.
+// Return the new configuration stats.
+// TODO: expose and return the config znode itself like the Java client does.
+func (c *Conn) IncrementalReconfig(joining, leaving []string, version int64) (*Stat, error) {
+	// TODO: validate the shape of the member string to give early feedback.
+	request := &reconfigRequest{
+		JoiningServers: []byte(strings.Join(joining, ",")),
+		LeavingServers: []byte(strings.Join(leaving, ",")),
+		CurConfigId:    version,
+	}
+
+	return c.internalReconfig(request)
+}
+
+// Reconfig is the non-incremental update functionality for Zookeeper where the list preovided
+// is the entire new member list.
+// the optional version allows for conditional reconfigurations, -1 ignores the condition.
+// TODO: expose and return the config znode itself like the Java client does.
+func (c *Conn) Reconfig(members []string, version int64) (*Stat, error) {
+	request := &reconfigRequest{
+		NewMembers:  []byte(strings.Join(members, ",")),
+		CurConfigId: version,
+	}
+
+	return c.internalReconfig(request)
+}
+
+func (c *Conn) internalReconfig(request *reconfigRequest) (*Stat, error) {
+	response := &reconfigReponse{}
+	_, err := c.request(opReconfig, request, response, nil)
+	return &response.Stat, err
 }
 
 // Server returns the current or last-connected server name.

--- a/zk/conn_test.go
+++ b/zk/conn_test.go
@@ -22,7 +22,7 @@ func TestRecurringReAuthHang(t *testing.T) {
 		}
 	}()
 
-	zkC, err := StartTestCluster(2, ioutil.Discard, ioutil.Discard)
+	zkC, err := StartTestCluster(t, 2, ioutil.Discard, ioutil.Discard)
 	if err != nil {
 		panic(err)
 	}

--- a/zk/dnshostprovider_test.go
+++ b/zk/dnshostprovider_test.go
@@ -16,7 +16,7 @@ func localhostLookupHost(host string) ([]string, error) {
 // TestDNSHostProviderCreate is just like TestCreate, but with an
 // overridden HostProvider that ignores the provided hostname.
 func TestDNSHostProviderCreate(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ var _ HostProvider = &localHostPortsFacade{}
 // remaps addresses to localhost:$PORT combinations corresponding to
 // the test ZooKeeper instances.
 func TestDNSHostProviderReconnect(t *testing.T) {
-	ts, err := StartTestCluster(3, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 3, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/zk/lock_test.go
+++ b/zk/lock_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLock(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,11 +64,12 @@ func TestLock(t *testing.T) {
 // This tests creating a lock with a path that's more than 1 node deep (e.g. "/test-multi-level/lock"),
 // when a part of that path already exists (i.e. "/test-multi-level" node already exists).
 func TestMultiLevelLock(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ts.Stop()
+
 	zk, _, err := ts.ConnectAll()
 	if err != nil {
 		t.Fatalf("Connect returned error: %+v", err)

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -36,7 +36,7 @@ type TestCluster struct {
 
 func StartTestCluster(t *testing.T, size int, stdout, stderr io.Writer) (*TestCluster, error) {
 	if testing.Short() {
-		t.Skip("ZK clsuter tests skipped in short case.")
+		t.Skip("ZK cluster tests skipped in short case.")
 	}
 	tmpPath, err := ioutil.TempDir("", "gozk")
 	requireNoError(t, err, "failed to create tmp dir for test server setup")

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -17,7 +17,7 @@ func (e ErrMissingServerConfigField) Error() string {
 }
 
 const (
-	DefaultServerTickTime                 = 2000
+	DefaultServerTickTime                 = 500
 	DefaultServerInitLimit                = 10
 	DefaultServerSyncLimit                = 5
 	DefaultServerAutoPurgeSnapRetainCount = 3
@@ -29,8 +29,8 @@ type server struct {
 	stdout, stderr io.Writer
 	cmdString      string
 	cmdArgs        []string
-
-	cmd *exec.Cmd
+	cmdEnv         []string
+	cmd            *exec.Cmd
 	// this cancel will kill the command being run in this case the server itself.
 	cancelFunc context.CancelFunc
 }
@@ -47,10 +47,13 @@ func NewIntegrationTestServer(t *testing.T, configPath string, stdout, stderr io
 			return nil, fmt.Errorf("zk: could not find testing zookeeper bin path at %q: %v ", zkPath, err)
 		}
 	}
+	// password is 'test'
+	superString := `SERVER_JVMFLAGS=-Dzookeeper.DigestAuthenticationProvider.superDigest=super:D/InIHSb7yEEbrWz8b9l71RjZJU=`
 
 	return &server{
 		cmdString: filepath.Join(zkPath, "zkServer.sh"),
 		cmdArgs:   []string{"start-foreground", configPath},
+		cmdEnv:    []string{superString},
 		stdout:    stdout, stderr: stderr,
 	}, nil
 }
@@ -62,6 +65,8 @@ func (srv *server) Start() error {
 	srv.cmd = exec.CommandContext(ctx, srv.cmdString, srv.cmdArgs...)
 	srv.cmd.Stdout = srv.stdout
 	srv.cmd.Stderr = srv.stderr
+
+	srv.cmd.Env = srv.cmdEnv
 	return srv.cmd.Start()
 }
 
@@ -119,16 +124,46 @@ func (sc ServerConfig) Marshall(w io.Writer) error {
 		fmt.Fprintf(w, "autopurge.snapRetainCount=%d\n", sc.AutoPurgeSnapRetainCount)
 		fmt.Fprintf(w, "autopurge.purgeInterval=%d\n", sc.AutoPurgePurgeInterval)
 	}
-	if len(sc.Servers) > 0 {
-		for _, srv := range sc.Servers {
-			if srv.PeerPort <= 0 {
-				srv.PeerPort = DefaultPeerPort
-			}
-			if srv.LeaderElectionPort <= 0 {
-				srv.LeaderElectionPort = DefaultLeaderElectionPort
-			}
-			fmt.Fprintf(w, "server.%d=%s:%d:%d\n", srv.ID, srv.Host, srv.PeerPort, srv.LeaderElectionPort)
-		}
+	// enable reconfig.
+	// TODO: allow setting this
+	fmt.Fprintln(w, "reconfigEnabled=true")
+	fmt.Fprintln(w, "4lw.commands.whitelist=*")
+
+	if len(sc.Servers) < 2 {
+		// if we dont have more than 2 servers we just dont specify server list to start in standalone mode
+		// see https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode for more details.
+		return nil
 	}
+	// if we then have more than one server force it to be distributed
+	fmt.Fprintln(w, "standaloneEnabled=false")
+
+	for _, srv := range sc.Servers {
+		if srv.PeerPort <= 0 {
+			srv.PeerPort = DefaultPeerPort
+		}
+		if srv.LeaderElectionPort <= 0 {
+			srv.LeaderElectionPort = DefaultLeaderElectionPort
+		}
+		fmt.Fprintf(w, "server.%d=%s:%d:%d\n", srv.ID, srv.Host, srv.PeerPort, srv.LeaderElectionPort)
+	}
+	return nil
+}
+
+// this is a helper to wait for the zk connection to at least get to the HasSession state
+func waitForSession(ctx context.Context, eventChan <-chan Event) error {
+	select {
+	case event, ok := <-eventChan:
+		// The eventChan is used solely to determine when the ZK conn has
+		// stopped.
+		if !ok {
+			return fmt.Errorf("connection closed before state reached")
+		}
+		if event.State == StateHasSession {
+			return nil
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
 	return nil
 }

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -277,6 +277,18 @@ type multiResponse struct {
 	DoneHeader multiHeader
 }
 
+// zk version 3.5 reconfig API
+type reconfigRequest struct {
+	JoiningServers []byte
+	LeavingServers []byte
+	NewMembers     []byte
+	// curConfigId version of the current configuration
+	// optional - causes reconfiguration to return an error if configuration is no longer current
+	CurConfigId int64
+}
+
+type reconfigReponse getDataResponse
+
 func (r *multiRequest) Encode(buf []byte) (int, error) {
 	total := 0
 	for _, op := range r.Ops {
@@ -604,6 +616,8 @@ func requestStructForOp(op int32) interface{} {
 		return &CheckVersionRequest{}
 	case opMulti:
 		return &multiRequest{}
+	case opReconfig:
+		return &reconfigRequest{}
 	}
 	return nil
 }

--- a/zk/structs_test.go
+++ b/zk/structs_test.go
@@ -15,6 +15,7 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})
 	encodeDecodeTest(t, &CheckVersionRequest{"/", -1})
+	encodeDecodeTest(t, &reconfigRequest{nil, nil, nil, -1})
 	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &CheckVersionRequest{"/", -1}}}})
 }
 

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestStateChanges(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestStateChanges(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestMulti(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	// reconnect.
 	testNode := "/auth-testnode"
 
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestMultiFailures(t *testing.T) {
 	const firstPath = "/gozk-test-first"
 	const secondPath = "/gozk-test-second"
 
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestMultiFailures(t *testing.T) {
 }
 
 func TestGetSetACL(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestGetSetACL(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +334,7 @@ func TestAuth(t *testing.T) {
 }
 
 func TestChildren(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestChildren(t *testing.T) {
 }
 
 func TestChildWatch(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestChildWatch(t *testing.T) {
 }
 
 func TestSetWatchers(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -601,7 +601,7 @@ func TestSetWatchers(t *testing.T) {
 }
 
 func TestExpiringWatch(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -667,7 +667,7 @@ func TestRequestFail(t *testing.T) {
 }
 
 func TestSlowServer(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -784,7 +784,7 @@ func startSlowProxy(t *testing.T, up, down Rate, upstream string, adj func(ln *L
 }
 
 func TestMaxBufferSize(t *testing.T) {
-	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	ts, err := StartTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Supersedes #205 

* changes travis tests to handle all versions of the ZK binary distribution.
* Adding new APIs IncrementalReconfig and Reconfig to support 3.5 reconfig options.

tested on ZK 3.5.4-beta 5 node zk clusters with simple add and remove actions beyond the integration tests included in this PR.

Fixes #204