### PR TITLE
Fix struct encode and decode for Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.11
-  - 1.9
+  - "1.11"
+  - "1.x"
   - tip
 
 go_import_path: github.com/samuel/go-zookeeper

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -404,7 +405,7 @@ type encoder interface {
 func decodePacket(buf []byte, st interface{}) (n int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if e, ok := r.(runtime.Error); ok && e.Error() == "runtime error: slice bounds out of range" {
+			if e, ok := r.(runtime.Error); ok && strings.HasPrefix(e.Error(), "runtime error: slice bounds out of range") {
 				err = ErrShortBuffer
 			} else {
 				panic(r)
@@ -495,7 +496,7 @@ func decodePacketValue(buf []byte, v reflect.Value) (int, error) {
 func encodePacket(buf []byte, st interface{}) (n int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if e, ok := r.(runtime.Error); ok && e.Error() == "runtime error: slice bounds out of range" {
+			if e, ok := r.(runtime.Error); ok && strings.HasPrefix(e.Error(), "runtime error: slice bounds out of range") {
 				err = ErrShortBuffer
 			} else {
 				panic(r)


### PR DESCRIPTION
Comparing the string for a runtime error isn't great, but leaving the existing behavior and making it work in Go 1.13beta1.

Fixes #215