### PR TITLE
Update constants.go to include a persistent flag

### DIFF
--- a/zk/constants.go
+++ b/zk/constants.go
@@ -70,6 +70,7 @@ const (
 )
 
 const (
+	FlagPersistent = 0
 	FlagEphemeral = 1
 	FlagSequence  = 2
 )


### PR DESCRIPTION
It seems odd that there isn't a flag for persistent while there is one for ephemeral and sequence. I think it would be clearer to just use a constant rather than 0.