### PR TITLE
Fix Conn.Close() infinity waiting problem

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -979,8 +979,7 @@ func (c *Conn) queueRequestWithContext(ctx context.Context, opcode int32, req in
 
 	select {
 	case <-ctx.Done():
-		rq.recvChan <- response{err: ErrConnectionClosed}
-		return rq.recvChan, ctx.Err()
+		return nil, ctx.Err()
 	case c.sendChan <- rq:
 		return rq.recvChan, nil
 	}


### PR DESCRIPTION
Issue https://github.com/samuel/go-zookeeper/issues/211 has been biting us for a while.  It is a bug in conn.go where `queueRequest()` stucks at sending request to a full yet no receiver channel.  I added a separate function for allowing timeout when enqueuing a request.