### PR TITLE
zk: add ReadOnly flag always set to false

### DIFF
--- a/zk/structs.go
+++ b/zk/structs.go
@@ -149,6 +149,7 @@ type connectRequest struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	ReadOnly        bool // always false as we don't support ro mode
 }
 
 type connectResponse struct {
@@ -156,6 +157,7 @@ type connectResponse struct {
 	TimeOut         int32
 	SessionID       int64
 	Passwd          []byte
+	ReadOnly        bool
 }
 
 type CreateRequest struct {

--- a/zk/structs_test.go
+++ b/zk/structs_test.go
@@ -8,8 +8,8 @@ import (
 func TestEncodeDecodePacket(t *testing.T) {
 	t.Parallel()
 	encodeDecodeTest(t, &requestHeader{-2, 5})
-	encodeDecodeTest(t, &connectResponse{1, 2, 3, nil})
-	encodeDecodeTest(t, &connectResponse{1, 2, 3, []byte{4, 5, 6}})
+	encodeDecodeTest(t, &connectResponse{1, 2, 3, nil, false})
+	encodeDecodeTest(t, &connectResponse{1, 2, 3, []byte{4, 5, 6}, false})
 	encodeDecodeTest(t, &getAclResponse{[]ACL{{12, "s", "anyone"}}, Stat{}})
 	encodeDecodeTest(t, &getChildrenResponse{[]string{"foo", "bar"}})
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})


### PR DESCRIPTION
Needed to work with newer servers that expect the field or log a WARN otherwise.
Does not implement readonly mode, just fixes #86.