### PR TITLE
Fix: Exists() should always return false when an error happenning

### DIFF
--- a/zk/conn.go
+++ b/zk/conn.go
@@ -1138,8 +1138,10 @@ func (c *Conn) Exists(path string) (bool, *Stat, error) {
 	res := &existsResponse{}
 	_, err := c.request(opExists, &existsRequest{Path: path, Watch: false}, res, nil)
 	exists := true
-	if err == ErrNoNode {
+	if err != nil {
 		exists = false
+	}
+	if err == ErrNoNode {
 		err = nil
 	}
 	return exists, &res.Stat, err


### PR DESCRIPTION
### Description

Exists() will return true with an error except `ErrNoNode`:

error happened | result | error returned
--- | --- | ---
nil | true | nil
ErrNoNode | false | nil
Any other | true(incorrect) | error

In addition `ExistsW()` acts correctly.
