### PR TITLE
If there is no parent node, the node is created level by level

### DIFF
--- a/zk/constants.go
+++ b/zk/constants.go
@@ -70,8 +70,9 @@ const (
 )
 
 const (
-	FlagEphemeral = 1
-	FlagSequence  = 2
+	FlagPersistence = 0
+	FlagEphemeral   = 1
+	FlagSequence    = 2
 )
 
 var (


### PR DESCRIPTION
The current method can only create nodes one level at a time, adding the method of creating nodes step by step. If there is no parent node, create the parent node first