### PR TITLE
AddingPowerSupport_golang-github-samuel-go-zookeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 go:
   - "1.11"


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
